### PR TITLE
Fix decryption extension maps

### DIFF
--- a/www/mods/gomori-sdk/scripts/GOMORI SDK.js
+++ b/www/mods/gomori-sdk/scripts/GOMORI SDK.js
@@ -82,10 +82,10 @@ function decryptAllFiles() {
         switch (ext) {
             case '.KEL':
             case '.AUBREY':
-            case '.PLUTO':
                 return '.json';
             case '.HERO':
-                return '.yml';
+            case '.PLUTO':
+                return '.yaml';
             case '.OMORI':
                 return '.js';
             case '.rpgmvp':


### PR DESCRIPTION
A fix for the GOMORI on-board decryptor that corrects file extensions that were previously being incorrectly mapped. Fixes #4 