### PR TITLE
Some bugfixes

### DIFF
--- a/www/gomori/lib/ModLoader.js
+++ b/www/gomori/lib/ModLoader.js
@@ -71,6 +71,9 @@ class ModLoader {
 			const isZip = modDir.endsWith(".zip");
 			const id = modDir.replace(".zip", "");
 			if (id.startsWith("_")) continue;
+			// Skip loading "mod" if its a file and not a zip
+			var base = path.dirname(process.mainModule.filename);
+			if (fs.lstatSync(base + "/mods/" + modDir).isFile() && !isZip) continue;
 
 			if (this.mods.has(id)) {
 				alert(`Cannot load mod "${modDir}" for having a conflicting ID.`);

--- a/www/mods/gomori/scripts/GOMORI Options.js
+++ b/www/mods/gomori/scripts/GOMORI Options.js
@@ -190,11 +190,6 @@ Window_OmoMenuOptionsMods.prototype.cursorRight = function(wrap) {
 	Window_Selectable.prototype.cursorRight.call(this, wrap);
 	// Get Data
 	var data = this._optionsList[this.index()];
-	// Get Data
-	if(this.index() === 0 && !Graphics._isFullScreen()) {
-		SoundManager.playBuzzer();
-		return;
-	}
 	if (data) {
 		// Set Data Index
 		data.index = (data.index + 1) % data.options.length;
@@ -212,11 +207,6 @@ Window_OmoMenuOptionsMods.prototype.cursorLeft = function(wrap) {
 	Window_Selectable.prototype.cursorLeft.call(this, wrap);
 	// Get Data
 	var data = this._optionsList[this.index()];
-	// Get Data
-	if(this.index() === 0 && !Graphics._isFullScreen()) {
-		SoundManager.playBuzzer();
-		return;
-	}
 	if (data) {
 		// Get Max Items
 		var maxItems = data.options.length;


### PR DESCRIPTION
- Removed inability to toggle first mod when fullscreen:
Noticed I couldn't toggle my own mod when fullscreen and found these bits of code inside.  Perhaps leftover from copying and pasting code from the Screen Resolution option in the general tab?
- Skip loading mod if its a file and not a zip:
Noticed that reads a file as a folder if left in the mods folder resulting in a crash.  Added a check if its a loose file that continues the mod directory iteration 