### PR TITLE
Notify users to launch only from steam

### DIFF
--- a/www/gomori/utils/encryption.js
+++ b/www/gomori/utils/encryption.js
@@ -3,6 +3,12 @@ const crypto = require("crypto");
 const ALGORITHM = "aes-256-ctr";
 const KEY = String(window.nw.App.argv).replace("--", "");
 
+if (KEY.length === 0) {
+	alert("Please do not directly launch OMORI. Use Steam instead.")
+	process.exit(0)
+}
+
+
 function encryptBuffer (buf, iv) {
 	const cipher = crypto.createCipheriv(ALGORITHM, KEY, iv);
 	const encryptedBuffer = Buffer.concat([iv, cipher.update(buf), cipher.final()]);


### PR DESCRIPTION
Not everyone notices that you need to get the encryption key from an argument on Steam. This will alert the user to launch through steam, then close the game.
Should help with #13.