### PR TITLE
Don't create BASIL if a BASIL already exists

### DIFF
--- a/www/gomori/lib/ModFile.js
+++ b/www/gomori/lib/ModFile.js
@@ -63,7 +63,7 @@ class ModFile {
 	}
 
 	patch() {
-		if (this.type.patch && exists(this.patchPath)) write(this.basilPath, this.unpatchedEncryptedBuffer);
+		if (this.type.patch && exists(this.patchPath) && !exists(this.basilPath)) write(this.basilPath, this.unpatchedEncryptedBuffer);
 		if (this.type.encrypted === "OMORI" && !this.mod.modLoader.plugins.some(({ name }) => name === this.pluginMeta.name)) this.mod.modLoader.plugins.push(this.pluginMeta);
 		if (this.type.patch) {
 			if (this.type.delta) {


### PR DESCRIPTION
- Saves time on startup as the BASIL does not need to be recreated
- Without this change, using multiple delta patches on a single file results in the each delta patch subsequently getting saved into the BASIL
  - This can lead to crashes on next boot if the delta patch removed data, as the data will no longer be there to remove

Users upgrading to OMORI 1.0.8 will need to delete their old BASIL files as well as mods.json, but I believe this is a small price to pay for the ability to use multiple delta patches on a single file (especially large database JSONs like CommonEvents, Skills, etc.). Clearing out all the old BASIL files can easily be accomplished with a single-line batch script.