### PR TITLE
Add obsolescence notice + OneLoader redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# ⚠️ GOMORI is no longer supported or maintained. ⚠️
+## Many mods will not function as intended with GOMORI.
+## Please use the new [OneLoader](https://github.com/rphsoftware/OneLoader) software to play OMORI with mods.
+
+----
+
 # Gilbert's Mod Loader
 This is a simple mod loader for OMORI. Installation instructions + modding documentation down below.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚠️ GOMORI is no longer supported or maintained. ⚠️
 ## Many mods will not function as intended with GOMORI.
-## Please use the new [OneLoader](https://github.com/rphsoftware/OneLoader) software to play OMORI with mods.
+## Consider using alternative mod loaders, such as [OneLoader](https://github.com/rphsoftware/OneLoader), instead.
 
 ----
 


### PR DESCRIPTION
Many users still download GOMORI because it is a top result in search engines when researching how to mod OMORI.
This notice will encourage them to use the updated and maintained OneLoader software instead.